### PR TITLE
Fix shutdown.

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,4 +42,4 @@ if __name__ == '__main__':
     # Wait until the proxy stops running, indicating that the gateway shut us
     # down.
     while _ADAPTER.proxy_running():
-        time.sleep(5)
+        time.sleep(2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tplink-adapter",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "TP-Link smart plug/bulb adapter plugin for Mozilla IoT Gateway",
   "author": "Mozilla IoT",
   "main": "main.py",


### PR DESCRIPTION
The gateway only waits 3 seconds before killing the process, so
we shouldn't be sleeping for 5 seconds.